### PR TITLE
Update tests (again)

### DIFF
--- a/tests/testthat/helper-guide-angle.R
+++ b/tests/testthat/helper-guide-angle.R
@@ -1,0 +1,8 @@
+
+get_guide_angle <- function(plot, guide = "x") {
+  if (inherits(plot$guides, "Guides")) {
+    plot$guides$guides[[guide]]$params$angle
+  } else {
+    plot$guides$x$angle
+  }
+}

--- a/tests/testthat/test-plot_3d_scatterbar.R
+++ b/tests/testthat/test-plot_3d_scatterbar.R
@@ -58,9 +58,5 @@ test_that("Check 3d scatter bars", {
   expect_match(as.character(rlang::quo_get_expr(sb1$labels$fill)), 
                "Genotype")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(sb1$guides$x$angle, 45)
-  } else {
-    expect_equal(sb1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(sb1, "x"), 45)
 })

--- a/tests/testthat/test-plot_3d_scatterbox.R
+++ b/tests/testthat/test-plot_3d_scatterbox.R
@@ -57,9 +57,5 @@ test_that("Check 3d scatter box", {
   #expect_match(sb1$labels$shape, "Time")
   #expect_match(sb1$labels$fill, "Genotype")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(sb1$guides$x$angle, 45)
-  } else {
-    expect_equal(sb1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(sb1, "x"), 45)
 })

--- a/tests/testthat/test-plot_3d_scatterviolin.R
+++ b/tests/testthat/test-plot_3d_scatterviolin.R
@@ -57,9 +57,5 @@ test_that("Check 3d scatter bars", {
   #expect_match(sb1$labels$shape,"Time")
   #expect_match(sb1$labels$fill, "Genotype")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(sb1$guides$x$angle, 45)
-  } else {
-    expect_equal(sb1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(sb1, "x"), 45)
 })

--- a/tests/testthat/test-plot_4d_scatterbar.R
+++ b/tests/testthat/test-plot_4d_scatterbar.R
@@ -22,9 +22,5 @@ test_that("Check 4d scatter bars", {
   #expect_match(sb1$labels$fill, 
   #             "Time")
   ##check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(sb1$guides$x$angle, 45)
-  } else {
-    expect_equal(sb1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(sb1, "x"), 45)
 })

--- a/tests/testthat/test-plot_4d_scatterbox.R
+++ b/tests/testthat/test-plot_4d_scatterbox.R
@@ -22,9 +22,5 @@ test_that("Check 4d scatter box", {
   #expect_match(sb1$labels$fill, 
   #             "Time")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(sb1$guides$x$angle, 45)
-  } else {
-    expect_equal(sb1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(sb1, "x"), 45)
 })

--- a/tests/testthat/test-plot_4d_scatterviolin.R
+++ b/tests/testthat/test-plot_4d_scatterviolin.R
@@ -22,9 +22,5 @@ test_that("Check 4d scatter box", {
   #expect_match(sb1$labels$fill, 
   #             "Time")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(sb1$guides$x$angle, 45)
-  } else {
-    expect_equal(sb1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(sb1, "x"), 45)
 })

--- a/tests/testthat/test-plot_befafter_colors.R
+++ b/tests/testthat/test-plot_befafter_colors.R
@@ -17,11 +17,7 @@ test_that("Check before-after colors plots", {
   expect_match(db1$labels$y, 
                "PI")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(db1$guides$x$angle, 45)
-  } else {
-    expect_equal(db1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(db1, "x"), 45)
 })
 
 test_that("Check before-after colour plots", {
@@ -41,11 +37,7 @@ test_that("Check before-after colour plots", {
   expect_match(db2$labels$y, 
                "PI")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(db2$guides$x$angle, 45)
-  } else {
-    expect_equal(db2$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(db2, "x"), 45)
 })
 
 test_that("Check before-after shapes plots", {
@@ -65,11 +57,6 @@ test_that("Check before-after shapes plots", {
   expect_match(db2$labels$y, 
                "PI")
   #check text angle is passed on
-  
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(db2$guides$x$angle, 45)
-  } else {
-    expect_equal(db2$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(db2, "x"), 45)
 })
 

--- a/tests/testthat/test-plot_dotbar_sd.R
+++ b/tests/testthat/test-plot_dotbar_sd.R
@@ -19,9 +19,5 @@ test_that("Check dotbar-sd plots", {
   expect_match(as.character(rlang::quo_get_expr(db1$labels$fill)), 
                "Genotype")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(db1$guides$x$angle, 45)
-  } else {
-    expect_equal(db1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(db1, "x"), 45)
 })

--- a/tests/testthat/test-plot_dotbox.R
+++ b/tests/testthat/test-plot_dotbox.R
@@ -19,10 +19,6 @@ test_that("Check dotbox plots", {
   expect_match(as.character(rlang::quo_get_expr(sb1$labels$fill)), 
                "Genotype")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(sb1$guides$x$angle, 45)
-  } else {
-    expect_equal(sb1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(sb1, "x"), 45)
 })
 

--- a/tests/testthat/test-plot_dotviolin.R
+++ b/tests/testthat/test-plot_dotviolin.R
@@ -19,9 +19,5 @@ test_that("Check dot violin plots", {
   expect_match(as.character(rlang::quo_get_expr(sb1$labels$fill)), 
                "Genotype")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(sb1$guides$x$angle, 45)
-  } else {
-    expect_equal(sb1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(sb1, "x"), 45)
 })

--- a/tests/testthat/test-plot_point_sd.R
+++ b/tests/testthat/test-plot_point_sd.R
@@ -19,10 +19,6 @@ test_that("Check point-sd plots", {
   expect_match(as.character(rlang::quo_get_expr(db1$labels$fill)), 
                "Genotype")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(db1$guides$x$angle, 45)
-  } else {
-    expect_equal(db1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(db1, "x"), 45)
 })
 

--- a/tests/testthat/test-plot_qqline.R
+++ b/tests/testthat/test-plot_qqline.R
@@ -13,11 +13,7 @@ test_that("Check QQ plots", {
   #match aesthetics in labels
   expect_match(as.character(db1$labels$y), "sample")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(db1$guides$x$angle, 45)
-  } else {
-    expect_equal(db1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(db1, "x"), 45)
 })
 
 
@@ -34,11 +30,7 @@ test_that("Check histogram plots", {
   #match aesthetics in labels
   #expect_match(as.character(db2$labels$y), "count")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(db2$guides$x$angle, 45)
-  } else {
-    expect_equal(db2$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(db2, "x"), 45)
 })
 
 
@@ -55,9 +47,5 @@ test_that("Check density plots", {
   #match aesthetics in labels
   #expect_match(as.character(db2$labels$y), "count")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(db2$guides$x$angle, 45)
-  } else {
-    expect_equal(db2$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(db2, "x"), 45)
 })

--- a/tests/testthat/test-plot_scatterbar_sd.R
+++ b/tests/testthat/test-plot_scatterbar_sd.R
@@ -19,10 +19,6 @@ test_that("Check scatter bar plots", {
   expect_match(as.character(rlang::quo_get_expr(sb1$labels$fill)), 
                "Genotype")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(sb1$guides$x$angle, 45)
-  } else {
-    expect_equal(sb1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(sb1, "x"), 45)
 })
 

--- a/tests/testthat/test-plot_scatterbox.R
+++ b/tests/testthat/test-plot_scatterbox.R
@@ -19,10 +19,6 @@ test_that("Check scatter box plots", {
   expect_match(as.character(rlang::quo_get_expr(sb1$labels$fill)), 
                "Genotype")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(sb1$guides$x$angle, 45)
-  } else {
-    expect_equal(sb1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(sb1, "x"), 45)
 })
 

--- a/tests/testthat/test-plot_scatterviolin.R
+++ b/tests/testthat/test-plot_scatterviolin.R
@@ -19,10 +19,6 @@ test_that("Check scatter violin plots", {
   expect_match(as.character(rlang::quo_get_expr(sb1$labels$fill)), 
                "Genotype")
   #check text angle is passed on
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(sb1$guides$x$angle, 45)
-  } else {
-    expect_equal(sb1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(sb1, "x"), 45)
 })
 

--- a/tests/testthat/test-plot_xy_CatGroup.R
+++ b/tests/testthat/test-plot_xy_CatGroup.R
@@ -7,9 +7,5 @@ test_that("XY plot and Cat groups works", {
   expect_equal(g1$theme$text$size, 20)
   expect_equal(g1$labels$x[1], "disp")
   expect_equal(g1$labels$y[1], "hp")
-  if (utils::packageVersion("ggplot2") <= "3.4.2") {
-    expect_equal(g1$guides$x$angle, 45)
-  } else {
-    expect_equal(g1$guides$x$angle, 45)
-  }
+  expect_equal(get_guide_angle(g1, "x"), 45)
 })

--- a/tests/testthat/test-scale_colour_grafify.R
+++ b/tests/testthat/test-scale_colour_grafify.R
@@ -17,7 +17,5 @@ test_that("Check colour and fill scales", {
   expect_match(db1$labels$y, "Doubling_time")
   expect_match(db1$labels$fill, "Student")
   expect_match(db1$labels$colour, "Student")
-  expect_match(db1$scales$scales[[1]]$scale_name, "muted")
-  expect_match(db1$scales$scales[[2]]$scale_name, "bright")
 })
 


### PR DESCRIPTION
Hi there,

Apologies for messing about with the same tests twice, but this is a follow up PR after #6.
We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break grafify.

The last time I changed the tests, I did so with the assumption that ggplot2 wouldn't release any intermediate versions. I've learned from this, and this time the tests aren't dependent on the version string of ggplot2. Aside from the axis angle tests, I have removed two tests that checked for the `scale_name` property of scales, which is deprecated in the new version of ggplot2.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help grafify get out a fix if necessary.